### PR TITLE
Fix/character name indexes

### DIFF
--- a/src/Game/characters.cpp
+++ b/src/Game/characters.cpp
@@ -1,6 +1,7 @@
 #include "characters.h"
 
-const int CHAR_NAMES_COUNT = charNames.size();
+// TODO: rework this file with better data structures
+const int CHAR_NAMES_COUNT = 41; // charNames.size();
 
 const std::vector<std::string> charNames
 {

--- a/src/PaletteManager/PaletteManager.cpp
+++ b/src/PaletteManager/PaletteManager.cpp
@@ -179,10 +179,12 @@ void PaletteManager::LoadPalettesIntoVector(CharIndex charIndex, std::wstring& w
 			if (charIndex != fileContents.header.charindex)
 			{
 				LOG(2, "WARNING, '%s' belongs to character %s, but is placed in folder %s\n",
-					fileName.c_str(), charNames[fileContents.header.charindex], charNames[charIndex]);
+					fileName.c_str(), charNames[fileContents.header.charindex].c_str(),
+					charNames[charIndex].c_str());
 
 				WindowManager::AddLog("[warning] '%s' belongs to character '%s', but is placed in folder '%s'\n", 
-					fileName.c_str(), charNames[fileContents.header.charindex], charNames[charIndex]);
+					fileName.c_str(), charNames[fileContents.header.charindex].c_str(),
+					charNames[charIndex].c_str());
 				//keep going
 			}
 
@@ -355,7 +357,7 @@ bool PaletteManager::PushImplFileIntoVector(CharIndex charIndex, IMPL_data_t & f
 
 	m_customPalettes[charIndex].push_back(filledPalData);
 
-	WindowManager::AddLog("[system] Loaded '%s%s' for character '%s'\n", filledPalData.palname, ".impl", charNames[charIndex]);
+	WindowManager::AddLog("[system] Loaded '%s%s' for character '%s'\n", filledPalData.palname, ".impl", charNames[charIndex].c_str());
 	return true;
 }
 

--- a/src/WindowManager/CustomHud.cpp
+++ b/src/WindowManager/CustomHud.cpp
@@ -488,11 +488,11 @@ void CustomHud::UpdateCharSpecificMeters(const CharInfo & charInfo, bool right_s
 		}
 
 		ImGui::SameLine();
-		ImGui::Text("%s", meterCharNames[charInfo.char_index]);
+		ImGui::Text("%s", meterCharNames[charInfo.char_index].c_str());
 	}
 	else
 	{
-		ImGui::Text("%s", meterCharNames[charInfo.char_index]);
+		ImGui::Text("%s", meterCharNames[charInfo.char_index].c_str());
 		ImGui::SameLine();
 
 		if (show_unique_bar)


### PR DESCRIPTION
Fixes:
- Crash upon loading palettes
- Missing logging strings
- Custom Hud character name abbreviation on custom meter